### PR TITLE
ISIS Support

### DIFF
--- a/layers/.lint_blacklist
+++ b/layers/.lint_blacklist
@@ -18,6 +18,7 @@ mpls.go
 ndp.go
 ntp.go
 ospf.go
+isis.go
 pflog.go
 pppoe.go
 prism.go

--- a/layers/enums.go
+++ b/layers/enums.go
@@ -273,6 +273,13 @@ const (
 	Dot11TypeDataQOSCFAckPollNoData Dot11Type = 0x3e
 )
 
+// OSI type is an enumeration of OSI Intradomain Routing Protocol Discriminator.
+type OSIType uint8
+
+const (
+	OSITypeISIS OSIType = 0x83
+)
+
 // Decode a raw v4 or v6 IP packet.
 func decodeIPv4or6(data []byte, p gopacket.PacketBuilder) error {
 	version := data[0] >> 4
@@ -440,4 +447,6 @@ func initActualTypeData() {
 	USBTransportTypeMetadata[USBTransportTypeInterrupt] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeUSBInterrupt), Name: "Interrupt", LayerType: LayerTypeUSBInterrupt}
 	USBTransportTypeMetadata[USBTransportTypeControl] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeUSBControl), Name: "Control", LayerType: LayerTypeUSBControl}
 	USBTransportTypeMetadata[USBTransportTypeBulk] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeUSBBulk), Name: "Bulk", LayerType: LayerTypeUSBBulk}
+
+	OSITypeMetadata[OSITypeISIS] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeISIS), Name: "ISIS", LayerType: LayerTypeISIS}
 }

--- a/layers/enums_generated.go
+++ b/layers/enums_generated.go
@@ -3,7 +3,7 @@
 package layers
 
 // Created by gen2.go, don't edit manually
-// Generated at 2017-10-23 10:20:24.458771856 -0600 MDT m=+0.001159033
+// Generated at 2023-01-20 14:01:47.829824 +0300 MSK m=+0.000936209
 
 import (
 	"fmt"
@@ -23,6 +23,7 @@ func init() {
 	initUnknownTypesForProtocolFamily()
 	initUnknownTypesForDot11Type()
 	initUnknownTypesForUSBTransportType()
+	initUnknownTypesForOSIType()
 	initActualTypeData()
 }
 
@@ -429,6 +430,43 @@ func initUnknownTypesForUSBTransportType() {
 		USBTransportTypeMetadata[i] = EnumMetadata{
 			DecodeWith: &errorDecodersForUSBTransportType[i],
 			Name:       "UnknownUSBTransportType",
+		}
+	}
+}
+
+// Decoder calls OSITypeMetadata.DecodeWith's decoder.
+func (a OSIType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return OSITypeMetadata[a].DecodeWith.Decode(data, p)
+}
+
+// String returns OSITypeMetadata.Name.
+func (a OSIType) String() string {
+	return OSITypeMetadata[a].Name
+}
+
+// LayerType returns OSITypeMetadata.LayerType.
+func (a OSIType) LayerType() gopacket.LayerType {
+	return OSITypeMetadata[a].LayerType
+}
+
+type errorDecoderForOSIType int
+
+func (a *errorDecoderForOSIType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return a
+}
+func (a *errorDecoderForOSIType) Error() string {
+	return fmt.Sprintf("Unable to decode OSIType %d", int(*a))
+}
+
+var errorDecodersForOSIType [256]errorDecoderForOSIType
+var OSITypeMetadata [256]EnumMetadata
+
+func initUnknownTypesForOSIType() {
+	for i := 0; i < 256; i++ {
+		errorDecodersForOSIType[i] = errorDecoderForOSIType(i)
+		OSITypeMetadata[i] = EnumMetadata{
+			DecodeWith: &errorDecodersForOSIType[i],
+			Name:       "UnknownOSIType",
 		}
 	}
 }

--- a/layers/gen2.go
+++ b/layers/gen2.go
@@ -4,11 +4,12 @@
 // that can be found in the LICENSE file in the root of the source
 // tree.
 
+//go:build ignore
 // +build ignore
 
 // This binary handles creating string constants and function templates for enums.
 //
-//  go run gen.go | gofmt > enums_generated.go
+//  go run gen2.go | gofmt > enums_generated.go
 package main
 
 import (
@@ -88,6 +89,7 @@ func main() {
 		{"ProtocolFamily", 256},
 		{"Dot11Type", 256},
 		{"USBTransportType", 256},
+		{"OSIType", 256},
 	}
 
 	fmt.Println("func init() {")

--- a/layers/isis.go
+++ b/layers/isis.go
@@ -1,0 +1,41 @@
+package layers
+
+import (
+	"github.com/google/gopacket"
+)
+
+type ISIS struct {
+	BaseLayer
+	// Describe packet fields
+	// Use OSPF (v2 or v3) as reference
+}
+
+func (isis *ISIS) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+
+	// Use (ospf *OSPFv2) DecodeFromBytes as reference
+
+	return nil
+}
+
+// LayerType returns LayerTypeISIS
+func (isis *ISIS) LayerType() gopacket.LayerType {
+	return LayerTypeISIS
+}
+
+// NextLayerType returns the layer type contained by this DecodingLayer.
+func (isis *ISIS) NextLayerType() gopacket.LayerType {
+	return gopacket.LayerTypeZero
+}
+
+// CanDecode returns the set of layer types that this DecodingLayer can decode.
+func (isis *ISIS) CanDecode() gopacket.LayerClass {
+	return LayerTypeISIS
+}
+
+func decodeISIS(data []byte, p gopacket.PacketBuilder) error {
+
+	// Check if packet is of correct type
+	// Use OSPF decodeOSPF as reference
+	isis := &ISIS{}
+	return decodingLayerDecoder(isis, data, p)
+}

--- a/layers/isis_test.go
+++ b/layers/isis_test.go
@@ -1,0 +1,5 @@
+package layers
+
+// See examples in ospf_test.go
+// Create similar tests for ISIS
+// Start from basic conversion: ISIS layer bytes -> parsed ISIS packet (i.e. Hello)

--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -148,7 +148,8 @@ var (
 	LayerTypeASFPresencePong              = gopacket.RegisterLayerType(144, gopacket.LayerTypeMetadata{Name: "ASFPresencePong", Decoder: gopacket.DecodeFunc(decodeASFPresencePong)})
 	LayerTypeERSPANII                     = gopacket.RegisterLayerType(145, gopacket.LayerTypeMetadata{Name: "ERSPAN Type II", Decoder: gopacket.DecodeFunc(decodeERSPANII)})
 	LayerTypeRADIUS                       = gopacket.RegisterLayerType(146, gopacket.LayerTypeMetadata{Name: "RADIUS", Decoder: gopacket.DecodeFunc(decodeRADIUS)})
-	LayerTypeISIS                         = gopacket.RegisterLayerType(147, gopacket.LayerTypeMetadata{Name: "ISIS", Decoder: gopacket.DecodeFunc(decodeISIS)})
+	LayerTypeOSI                          = gopacket.RegisterLayerType(147, gopacket.LayerTypeMetadata{Name: "OSI", Decoder: gopacket.DecodeFunc(decodeOSI)})
+	LayerTypeISIS                         = gopacket.RegisterLayerType(148, gopacket.LayerTypeMetadata{Name: "ISIS", Decoder: gopacket.DecodeFunc(decodeISIS)})
 )
 
 var (

--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -148,6 +148,7 @@ var (
 	LayerTypeASFPresencePong              = gopacket.RegisterLayerType(144, gopacket.LayerTypeMetadata{Name: "ASFPresencePong", Decoder: gopacket.DecodeFunc(decodeASFPresencePong)})
 	LayerTypeERSPANII                     = gopacket.RegisterLayerType(145, gopacket.LayerTypeMetadata{Name: "ERSPAN Type II", Decoder: gopacket.DecodeFunc(decodeERSPANII)})
 	LayerTypeRADIUS                       = gopacket.RegisterLayerType(146, gopacket.LayerTypeMetadata{Name: "RADIUS", Decoder: gopacket.DecodeFunc(decodeRADIUS)})
+	LayerTypeISIS                         = gopacket.RegisterLayerType(147, gopacket.LayerTypeMetadata{Name: "ISIS", Decoder: gopacket.DecodeFunc(decodeISIS)})
 )
 
 var (

--- a/layers/llc.go
+++ b/layers/llc.go
@@ -64,6 +64,8 @@ func (l *LLC) NextLayerType() gopacket.LayerType {
 		return LayerTypeSNAP
 	case l.DSAP == 0x42 && l.SSAP == 0x42:
 		return LayerTypeSTP
+	case l.DSAP == 0xfe && l.SSAP == 0xfe:
+		return LayerTypeOSI
 	}
 	return gopacket.LayerTypeZero // Not implemented
 }

--- a/layers/osi.go
+++ b/layers/osi.go
@@ -1,0 +1,49 @@
+package layers
+
+import (
+	"github.com/google/gopacket"
+)
+
+// For reference use Wireshark OSI dissector
+// https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-osi.c
+// https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-osi.h
+
+type OSI struct {
+	BaseLayer
+
+	// This type is defined in layers/enums.go
+	// All the methods for this type are auto-generated
+	// (see layers/enums_generated.go and layers/gen2.go for more details)
+	OSIType OSIType
+
+	// TODO Describe other header fields
+}
+
+func (osi *OSI) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+
+	// Use SNAP layer type decoder from layers/llc.go as reference
+	// TODO don't forget to assign value to osi.OSIType
+	return nil
+}
+
+// LayerType returns LayerTypeISIS
+func (osi *OSI) LayerType() gopacket.LayerType {
+	return LayerTypeOSI
+}
+
+// NextLayerType returns the layer type contained by this DecodingLayer.
+func (osi *OSI) NextLayerType() gopacket.LayerType {
+	return osi.OSIType.LayerType()
+}
+
+// CanDecode returns the set of layer types that this DecodingLayer can decode.
+func (osi *OSI) CanDecode() gopacket.LayerClass {
+	return LayerTypeOSI
+}
+
+func decodeOSI(data []byte, p gopacket.PacketBuilder) error {
+
+	// Check if packet is of correct type
+	osi := &OSI{}
+	return decodingLayerDecoder(osi, data, p)
+}


### PR DESCRIPTION
Create a new parser for ISIS protocol

To implement it we first need to create OSI header decoder. 
As a reference we use Wireshark OSI dissector:
https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-osi.c
https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-osi.h


Reference Wireshark dissectors for ISIS packets:
https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-isis.c
https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-isis.h
ISIS HELLO: https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-isis-hello.c
ISIS LSP: https://github.com/wireshark/wireshark/blob/master/epan/dissectors/packet-isis-lsp.c